### PR TITLE
feat: add "interpolative" search function

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ description = 'This crate implements the "eytzinger" (aka BFS) array layout.'
 license = "MIT"
 documentation = "https://docs.rs/eytzinger"
 repository = "https://github.com/main--/rust-eytzinger"
-version = "1.1.1"
+version = "1.1.2"
 authors = ["main() <main@ehvag.de>"]
 
 [profile.release]

--- a/benches/eytzinger.rs
+++ b/benches/eytzinger.rs
@@ -9,8 +9,8 @@
 // except according to those terms.
 #![feature(test)]
 
-extern crate test;
 extern crate eytzinger;
+extern crate test;
 
 use eytzinger::SliceExt;
 use test::black_box;
@@ -23,11 +23,12 @@ enum Cache {
 }
 
 fn eytzinger_search<F>(b: &mut Bencher, cache: Cache, mapper: F)
-    where F: Fn(usize) -> usize
+where
+    F: Fn(usize) -> usize,
 {
     let size = match cache {
-        Cache::L1 => 1000, // 8kb
-        Cache::L2 => 10_000, // 80kb
+        Cache::L1 => 1000,      // 8kb
+        Cache::L2 => 10_000,    // 80kb
         Cache::L3 => 1_000_000, // 8Mb
     };
     let mut v = (0..size).map(&mapper).collect::<Vec<_>>();

--- a/benches/standard.rs
+++ b/benches/standard.rs
@@ -11,8 +11,6 @@
 
 extern crate test;
 
-
-
 use test::black_box;
 use test::Bencher;
 
@@ -23,11 +21,12 @@ enum Cache {
 }
 
 fn binary_search<F>(b: &mut Bencher, cache: Cache, mapper: F)
-    where F: Fn(usize) -> usize
+where
+    F: Fn(usize) -> usize,
 {
     let size = match cache {
-        Cache::L1 => 1000, // 8kb
-        Cache::L2 => 10_000, // 80kb
+        Cache::L1 => 1000,      // 8kb
+        Cache::L2 => 10_000,    // 80kb
         Cache::L3 => 1_000_000, // 8Mb
     };
     let v = (0..size).map(&mapper).collect::<Vec<_>>();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -342,7 +342,7 @@ impl Permutation for PermutationGenerator {
 ///
 /// # Example
 ///
-/// ```
+/// ```rust
 /// let mut data = [0, 1, 2, 3, 4, 5, 6];
 /// eytzinger::eytzingerize(&mut data, &mut eytzinger::permutation::InplacePermutator);
 /// assert_eq!(data, [3, 1, 5, 0, 2, 4, 6]);
@@ -359,7 +359,7 @@ pub trait SliceExt<T> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust
     /// use eytzinger::SliceExt;
     /// let mut data = [0, 1, 2, 3, 4, 5, 6];
     /// data.eytzingerize(&mut eytzinger::permutation::InplacePermutator);
@@ -374,7 +374,7 @@ pub trait SliceExt<T> {
     ///
     /// # Example
     ///
-    /// ```
+    /// ```rust
     /// use eytzinger::SliceExt;
     /// let s = [3, 1, 5, 0, 2, 4, 6];
     /// assert_eq!(s.eytzinger_search(&5), Some(2));
@@ -397,7 +397,7 @@ pub trait SliceExt<T> {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```rust
     /// use eytzinger::SliceExt;
     /// let s = [3, 1, 5, 0, 2, 4, 6];
     /// assert_eq!(s.eytzinger_search_by(|x| x.cmp(&5)), Some(2));
@@ -420,7 +420,7 @@ pub trait SliceExt<T> {
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```rust
     /// use eytzinger::SliceExt;
     /// let s = [(3, 'd'), (1, 'b'), (5, 'f'), (0, 'a'), (2, 'c'), (4, 'e'), (6, 'g')];
     /// assert_eq!(s.eytzinger_search_by_key(&'f', |&(_, b)| b), Some(2));
@@ -433,6 +433,142 @@ pub trait SliceExt<T> {
         F: FnMut(&'a T) -> B,
         Q: Ord,
         T: 'a;
+
+    /// Binary searches this eytzinger slice with a comparator function for interpolation.
+    ///
+    /// Called "interpolative" search because it's useful for when you need to interpolate to a value between two values in the array.
+    ///
+    /// The comparator function should implement an order consistent with the sort order
+    /// of the underlying eytzinger slice, returning an order code that indicates whether
+    /// its argument is `Less`, `Equal` or `Greater` than the desired target.
+    ///
+    /// The first return value is the index of the highest value that's less than or equal to the target value.
+    /// The second return value is the index of the lowest value that's greater than to the target value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use eytzinger::SliceExt;
+    /// let s = [3, 1, 5, 0, 2, 4, 6];
+    /// assert_eq!(s.eytzinger_interpolative_search_by(|x| x.cmp(&3)),  (Some(0_usize), Some(5_usize)));
+    /// assert_eq!(s.eytzinger_interpolative_search_by(|x| x.cmp(&5)),  (Some(2_usize), Some(6_usize)));
+    /// assert_eq!(s.eytzinger_interpolative_search_by(|x| x.cmp(&6)),  (Some(6_usize), None));
+    /// assert_eq!(s.eytzinger_interpolative_search_by(|x| x.cmp(&7)),  (Some(6_usize), None));
+    /// assert_eq!(s.eytzinger_interpolative_search_by(|x| x.cmp(&0)),  (Some(3_usize), Some(1_usize)));
+    /// assert_eq!(s.eytzinger_interpolative_search_by(|x| x.cmp(&-1)), (None, Some(3_usize)));
+    /// assert_eq!(s.eytzinger_interpolative_search_by(|x| (*x as f32).partial_cmp(&3.5).unwrap()), (Some(0_usize), Some(5_usize)));
+    /// ```
+    fn eytzinger_interpolative_search_by<'a, F>(&'a self, f: F) -> (Option<usize>, Option<usize>)
+    where
+        F: FnMut(&'a T) -> Ordering,
+        T: 'a;
+
+    /// Binary searches this eytzinger slice for interpolation.
+    ///
+    /// The first return value is the index of the highest value that's less than or equal to the target value.
+    /// The second return value is the index of the lowest value that's greater than to the target value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use eytzinger::SliceExt;
+    /// let s = [3, 1, 5, 0, 2, 4, 6];
+    /// assert_eq!(s.eytzinger_interpolative_search(&3),  (Some(0_usize), Some(5_usize)));
+    /// assert_eq!(s.eytzinger_interpolative_search(&5),  (Some(2_usize), Some(6_usize)));
+    /// assert_eq!(s.eytzinger_interpolative_search(&6),  (Some(6_usize), None));
+    /// assert_eq!(s.eytzinger_interpolative_search(&7),  (Some(6_usize), None));
+    /// assert_eq!(s.eytzinger_interpolative_search(&0),  (Some(3_usize), Some(1_usize)));
+    /// assert_eq!(s.eytzinger_interpolative_search(&-1), (None, Some(3_usize)));
+    /// ```
+    fn eytzinger_interpolative_search<Q: ?Sized>(&self, x: &Q) -> (Option<usize>, Option<usize>)
+    where
+        Q: Ord,
+        T: Borrow<Q>;
+
+    /// Binary searches this sorted slice with a key extraction function for interpolation.
+    ///
+    /// Assumes that the slice is eytzinger-sorted by the key, for instance with
+    /// `slice::sort_by_key` combined with `eytzinger::eytzingerize` using the
+    /// same key extraction function.
+    ///
+    /// The first return value is the index of the highest value that's less than or equal to the target value.
+    /// The second return value is the index of the lowest value that's greater than to the target value.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use eytzinger::SliceExt;
+    /// let s = [(3, 'd'), (1, 'b'), (5, 'f'), (0, 'a'), (2, 'c'), (4, 'e'), (6, 'g')];
+    /// assert_eq!(s.eytzinger_interpolative_search_by_key(&'d', |&(_, b)| b), (Some(0), Some(5)));
+    /// assert_eq!(s.eytzinger_interpolative_search_by_key(&'f', |&(_, b)| b), (Some(2), Some(6)));
+    /// assert_eq!(s.eytzinger_interpolative_search_by_key(&'g', |&(_, b)| b), (Some(6), None));
+    /// assert_eq!(s.eytzinger_interpolative_search_by_key(&'x', |&(_, b)| b), (Some(6), None));
+    /// ```
+    fn eytzinger_interpolative_search_by_key<'a, B, F, Q: ?Sized>(&'a self, b: &Q, f: F) -> (Option<usize>, Option<usize>)
+    where
+        B: Borrow<Q>,
+        F: FnMut(&'a T) -> B,
+        Q: Ord,
+        T: 'a;
+
+}
+
+/// Binary searches this eytzinger slice with a comparator function.
+///
+/// Called "interpolative" search because it's useful because it's useful for when you need to interpolate to a value between two values in the array.
+///
+/// The comparator function should implement an order consistent with the sort order
+/// of the underlying eytzinger slice, returning an order code that indicates whether
+/// its argument is `Less`, `Equal` or `Greater` than the desired target.
+///
+/// The first return value is the index of the highest value that's less than or equal to the target value.
+/// The second return value is the index of the lowest value that's greater than to the target value.
+///
+/// # Examples
+///
+/// ```rust
+/// use eytzinger::eytzinger_interpolative_search_by;
+/// let s = [3, 1, 5, 0, 2, 4, 6];
+/// assert_eq!(eytzinger_interpolative_search_by(&s, |x| x.cmp(&3)),  (Some(0_usize), Some(5_usize)));
+/// assert_eq!(eytzinger_interpolative_search_by(&s, |x| x.cmp(&5)),  (Some(2_usize), Some(6_usize)));
+/// assert_eq!(eytzinger_interpolative_search_by(&s, |x| x.cmp(&6)),  (Some(6_usize), None));
+/// assert_eq!(eytzinger_interpolative_search_by(&s, |x| x.cmp(&7)),  (Some(6_usize), None));
+/// assert_eq!(eytzinger_interpolative_search_by(&s, |x| x.cmp(&0)),  (Some(3_usize), Some(1_usize)));
+/// assert_eq!(eytzinger_interpolative_search_by(&s, |x| x.cmp(&-1)), (None, Some(3_usize)));
+/// assert_eq!(eytzinger_interpolative_search_by(&s, |x| (*x as f32).partial_cmp(&3.5).unwrap()), (Some(0_usize), Some(5_usize)));
+/// ```
+#[inline]
+pub fn eytzinger_interpolative_search_by<'a, T: 'a, F>(
+    data: &'a [T],
+    mut f: F,
+) -> (Option<usize>, Option<usize>)
+where
+    F: FnMut(&'a T) -> Ordering,
+{
+    let mut lte: Option<usize> = None; // Index of highest value <= target
+    let mut gt: Option<usize> = None; // Index of lowest value > target
+    let mut i = 0;
+
+    while i < data.len() {
+        let v = &data[i];
+        match f(v) {
+            Ordering::Less | Ordering::Equal => {
+                // Current value <= target
+                lte = Some(i);
+                // Go right to find larger values (potentially better lte or gt)
+                i = 2 * i + 2;
+            }
+            Ordering::Greater => {
+                // Current value > target
+                // This is a candidate for gt (lowest value > target)
+                gt = Some(i);
+                // Go left to find smaller values (potentially lte or better gt)
+                i = 2 * i + 1;
+            }
+        }
+    }
+
+    (lte, gt)
 }
 
 /// Binary searches this eytzinger slice with a comparator function.
@@ -446,7 +582,7 @@ pub trait SliceExt<T> {
 ///
 /// # Examples
 ///
-/// ```
+/// ```rust
 /// use eytzinger::eytzinger_search_by;
 /// let s = [3, 1, 5, 0, 2, 4, 6];
 /// assert_eq!(eytzinger_search_by(&s, |x| x.cmp(&3)), Some(0));
@@ -548,6 +684,35 @@ impl<T> SliceExt<T> for [T] {
         T: 'a,
     {
         self.eytzinger_search_by(|k| f(k).borrow().cmp(b))
+    }
+
+    #[inline]
+    fn eytzinger_interpolative_search_by<'a, F>(&'a self, f: F) -> (Option<usize>, Option<usize>)
+    where
+        F: FnMut(&'a T) -> Ordering,
+        T: 'a,
+    {
+        eytzinger_interpolative_search_by(self, f)
+    }
+
+    #[inline]
+    fn eytzinger_interpolative_search<Q: ?Sized>(&self, x: &Q) -> (Option<usize>, Option<usize>)
+    where
+        Q: Ord,
+        T: Borrow<Q>,
+    {
+        self.eytzinger_interpolative_search_by(|e| e.borrow().cmp(x))
+    }
+
+    #[inline]
+    fn eytzinger_interpolative_search_by_key<'a, B, F, Q: ?Sized>(&'a self, b: &Q, mut f: F) -> (Option<usize>, Option<usize>)
+    where
+        B: Borrow<Q>,
+        F: FnMut(&'a T) -> B,
+        Q: Ord,
+        T: 'a,
+    {
+        self.eytzinger_interpolative_search_by(|k| f(k).borrow().cmp(b))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,9 @@
 
 #![warn(missing_docs, missing_debug_implementations)]
 
-use std::cmp::{Ord, Ordering};
-use std::borrow::Borrow;
 use permutation::*;
+use std::borrow::Borrow;
+use std::cmp::{Ord, Ordering};
 
 /// The basic building blocks this crate is made of.
 pub mod foundation {
@@ -101,7 +101,7 @@ pub mod permutation {
     pub trait Permutation {
         /// An iterator through the permutation.
         /// This may be more efficient than indexing a counter.
-        type Iter: Iterator<Item=usize>;
+        type Iter: Iterator<Item = usize>;
 
         /// Get an iterator.
         fn iterable(&self) -> Self::Iter;
@@ -129,7 +129,6 @@ pub mod permutation {
         fn permute(&mut self, data: &mut [T], permutation: &P);
     }
 
-
     /// Simple permutator that does not allocate.
     ///
     /// Worst-case runtime is in `O(n^2)`, so you should only use this for small permutations.
@@ -151,14 +150,16 @@ pub mod permutation {
         }
     }
 
-
     /// Simple permutator that stack-allocates a copy of the data (using recursion).
     ///
     /// Worst-case runtime is `O(n)`, but this takes `O(n)` stack space so it WILL NOT work for large permutations.
     #[derive(Clone, Copy, Debug, Default)]
     pub struct StackCopyPermutator;
 
-    fn recursive_permute<T: Clone, P: ?Sized + Permutation>(data: &mut [T], permutation: &mut Enumerate<P::Iter>) {
+    fn recursive_permute<T: Clone, P: ?Sized + Permutation>(
+        data: &mut [T],
+        permutation: &mut Enumerate<P::Iter>,
+    ) {
         if let Some((i, p)) = permutation.next() {
             let item = data[p].clone();
             recursive_permute::<T, P>(data, permutation);
@@ -174,7 +175,6 @@ pub mod permutation {
         }
     }
 
-
     /// Simple permutator that heap-allocates a copy of the data.
     ///
     /// Worst-case runtime is `O(n)`, taking `O(n)` heap space in a reusable buffer.
@@ -189,7 +189,8 @@ pub mod permutation {
         #[inline]
         fn permute(&mut self, data: &mut [T], permutation: &P) {
             self.buffer.clear();
-            self.buffer.extend(permutation.iterable().map(|i| data[i].clone()));
+            self.buffer
+                .extend(permutation.iterable().map(|i| data[i].clone()));
             for (i, t) in self.buffer.drain(..).enumerate() {
                 data[i] = t;
             }
@@ -269,8 +270,6 @@ pub mod permutation {
     }
 }
 
-
-
 /// Generates a permutation that transforms a sorted array into an eytzinger array.
 ///
 /// This is an iterator which yields a permutation (indexes into the sorted array)
@@ -312,7 +311,9 @@ impl Iterator for PermutationGenerator {
 
         let li = self.li;
         self.li += 1;
-        Some(foundation::get_permutation_element_by_node(self.size, self.ipk, li))
+        Some(foundation::get_permutation_element_by_node(
+            self.size, self.ipk, li,
+        ))
     }
 
     #[inline]
@@ -380,7 +381,10 @@ pub trait SliceExt<T> {
     /// assert_eq!(s.eytzinger_search(&6), Some(6));
     /// assert_eq!(s.eytzinger_search(&7), None);
     /// ```
-    fn eytzinger_search<Q: ?Sized>(&self, x: &Q) -> Option<usize> where Q: Ord, T: Borrow<Q>;
+    fn eytzinger_search<Q: ?Sized>(&self, x: &Q) -> Option<usize>
+    where
+        Q: Ord,
+        T: Borrow<Q>;
 
     /// Binary searches this eytzinger slice with a comparator function.
     ///
@@ -400,7 +404,10 @@ pub trait SliceExt<T> {
     /// assert_eq!(s.eytzinger_search_by(|x| x.cmp(&6)), Some(6));
     /// assert_eq!(s.eytzinger_search_by(|x| x.cmp(&7)), None);
     /// ```
-    fn eytzinger_search_by<'a, F>(&'a self, f: F) -> Option<usize> where F: FnMut(&'a T) -> Ordering, T: 'a;
+    fn eytzinger_search_by<'a, F>(&'a self, f: F) -> Option<usize>
+    where
+        F: FnMut(&'a T) -> Ordering,
+        T: 'a;
 
     /// Binary searches this sorted slice with a key extraction function.
     ///
@@ -421,10 +428,11 @@ pub trait SliceExt<T> {
     /// assert_eq!(s.eytzinger_search_by_key(&'x', |&(_, b)| b), None);
     /// ```
     fn eytzinger_search_by_key<'a, B, F, Q: ?Sized>(&'a self, b: &Q, f: F) -> Option<usize>
-        where B: Borrow<Q>,
-              F: FnMut(&'a T) -> B,
-              Q: Ord,
-              T: 'a;
+    where
+        B: Borrow<Q>,
+        F: FnMut(&'a T) -> B,
+        Q: Ord,
+        T: 'a;
 }
 
 /// Binary searches this eytzinger slice with a comparator function.
@@ -448,14 +456,18 @@ pub trait SliceExt<T> {
 /// ```
 #[inline]
 pub fn eytzinger_search_by<'a, T: 'a, F>(data: &'a [T], f: F) -> Option<usize>
-    where F: FnMut(&'a T) -> Ordering {
+where
+    F: FnMut(&'a T) -> Ordering,
+{
     eytzinger_search_by_impl(data, f)
 }
 
 #[inline]
 #[cfg(not(feature = "branchless"))]
 fn eytzinger_search_by_impl<'a, T: 'a, F>(data: &'a [T], mut f: F) -> Option<usize>
-    where F: FnMut(&'a T) -> Ordering {
+where
+    F: FnMut(&'a T) -> Ordering,
+{
     let mut i = 0;
     loop {
         match data.get(i) {
@@ -480,7 +492,9 @@ fn eytzinger_search_by_impl<'a, T: 'a, F>(data: &'a [T], mut f: F) -> Option<usi
 #[inline]
 #[cfg(feature = "branchless")]
 fn eytzinger_search_by_impl<'a, T: 'a, F>(data: &'a [T], mut f: F) -> Option<usize>
-    where F: FnMut(&'a T) -> Ordering {
+where
+    F: FnMut(&'a T) -> Ordering,
+{
     let mut i = 0;
     while i < data.len() {
         let v = &data[i]; // this range check is optimized out :D
@@ -508,37 +522,49 @@ impl<T> SliceExt<T> for [T] {
     }
 
     #[inline]
-    fn eytzinger_search<Q: ?Sized>(&self, x: &Q) -> Option<usize> where Q: Ord, T: Borrow<Q> {
+    fn eytzinger_search<Q: ?Sized>(&self, x: &Q) -> Option<usize>
+    where
+        Q: Ord,
+        T: Borrow<Q>,
+    {
         self.eytzinger_search_by(|e| e.borrow().cmp(x))
     }
 
     #[inline]
-    fn eytzinger_search_by<'a, F>(&'a self, f: F) -> Option<usize> where F: FnMut(&'a T) -> Ordering, T: 'a {
+    fn eytzinger_search_by<'a, F>(&'a self, f: F) -> Option<usize>
+    where
+        F: FnMut(&'a T) -> Ordering,
+        T: 'a,
+    {
         eytzinger_search_by(self, f)
     }
 
     #[inline]
     fn eytzinger_search_by_key<'a, B, F, Q: ?Sized>(&'a self, b: &Q, mut f: F) -> Option<usize>
-        where B: Borrow<Q>,
-              F: FnMut(&'a T) -> B,
-              Q: Ord,
-              T: 'a {
+    where
+        B: Borrow<Q>,
+        F: FnMut(&'a T) -> B,
+        Q: Ord,
+        T: 'a,
+    {
         self.eytzinger_search_by(|k| f(k).borrow().cmp(b))
     }
 }
-
 
 #[cfg(test)]
 #[macro_use]
 extern crate quickcheck;
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::foundation::*;
+    use super::*;
 
     #[test]
     fn magic() {
-        for (i, &v) in [0, 1, 1, 2, 3, 3, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8].iter().enumerate() {
+        for (i, &v) in [0, 1, 1, 2, 3, 3, 3, 4, 5, 6, 7, 7, 7, 7, 7, 8]
+            .iter()
+            .enumerate()
+        {
             assert_eq!(get_permutation_element_by_node(i + 1, 1, 0), v);
         }
         for (i, &v) in [0, 0, 1, 1, 1, 1, 2, 3, 3].iter().enumerate() {
@@ -653,7 +679,10 @@ mod tests {
         }
     }
 
-    fn test_permutation<P: Default>(junk: Vec<usize>) -> bool where for<'a> P: Permutator<usize, &'a [usize]> {
+    fn test_permutation<P: Default>(junk: Vec<usize>) -> bool
+    where
+        for<'a> P: Permutator<usize, &'a [usize]>,
+    {
         // first create a permutation from the random array
         let mut perm: Vec<_> = (0..junk.len()).collect();
         perm.sort_by_key(|&i| junk[i]);


### PR DESCRIPTION
This pull request adds an "interpolative" search function (perhaps a better name is possible) . It's designed to find the two closest values to a target value in an eytzinger array for interpolation purposes.

This is particularly useful when dealing with keyframes. Imagine you have a sequence of keyframes at specific times, and need to find the two surrounding keyframes for a given point in time to interpolate between them.

This functionality was difficult to implement with existing search functions since they expected exact matches, whereas the interpolative search function will find the nearest matches.

This is definitely not the most efficient implementation possible. Unfortunately, I'm not very experienced with such things, so I implemented it in the most straightforward way I could think of.

The new search function is tested using a doctest. For good measure, I also added doctests to the other search functions.

Note: The first commit runs Cargo format but makes no other changes. The second commit implements the interpolative search function.
